### PR TITLE
docs: Correct astronvim statement

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 NvChad community repo for sharing plugin configurations
 
-This is inspired by AstroNvim's community repo, although this isnt meant to be used always by non nvchad users, because it might contain code related to nvchad's base46 theme loading for certain plugins so watch-out!
+This is inspired by AstroNvim's community repo.
 
 # Usage
 


### PR DESCRIPTION
Hello from one of the astrocommunity mainters 👋🏾.

The current statement about Astronvim is not true.

AstroNvim's community repo will most definitely break when used in a non-astronvim config due to the heavy dependency on AstroNvim util modules. 
