### PR TITLE
Add plugin presence.nvim and add event LspAttach for error-lens.nvim

### DIFF
--- a/lua/nvcommunity/diagnostics/errorlens/init.lua
+++ b/lua/nvcommunity/diagnostics/errorlens/init.lua
@@ -2,6 +2,7 @@
 local spec = {
   {
     "chikko80/error-lens.nvim",
+    event = "BufRead",
     opts = {},
   },
 }

--- a/lua/nvcommunity/diagnostics/errorlens/init.lua
+++ b/lua/nvcommunity/diagnostics/errorlens/init.lua
@@ -2,7 +2,7 @@
 local spec = {
   {
     "chikko80/error-lens.nvim",
-    event = "BufRead",
+    event = "LspAttach",
     opts = {},
   },
 }

--- a/lua/nvcommunity/diagnostics/errorlens/readme.md
+++ b/lua/nvcommunity/diagnostics/errorlens/readme.md
@@ -1,0 +1,5 @@
+# Error Lens for Neovim
+
+[error-lens.nvim](https://github.com/chikko80/error-lens.nvim) an enhanced
+visual diagnostic display for Neovim, inspired by the Error Lens extension for
+Visual Studio Code.

--- a/lua/nvcommunity/tools/presence/init.lua
+++ b/lua/nvcommunity/tools/presence/init.lua
@@ -3,9 +3,7 @@ local spec = {
   {
     "andweeb/presence.nvim",
     event = "VimEnter",
-    config = function()
-      require("presence").setup {}
-    end,
+    opts = {},
   },
 }
 

--- a/lua/nvcommunity/tools/presence/init.lua
+++ b/lua/nvcommunity/tools/presence/init.lua
@@ -2,7 +2,7 @@
 local spec = {
   {
     "andweeb/presence.nvim",
-    event = "VeryLazy",
+    event = "VimEnter",
     config = function()
       require("presence").setup {}
     end,

--- a/lua/nvcommunity/tools/presence/init.lua
+++ b/lua/nvcommunity/tools/presence/init.lua
@@ -1,0 +1,12 @@
+---@type NvPluginSpec
+local spec = {
+  {
+    "andweeb/presence.nvim",
+    event = "VeryLazy",
+    config = function()
+      require("presence").setup {}
+    end,
+  },
+}
+
+return spec

--- a/lua/nvcommunity/tools/presence/readme.md
+++ b/lua/nvcommunity/tools/presence/readme.md
@@ -1,0 +1,3 @@
+# Presence
+
+[presence.nvim](https://github.com/andweeb/presence.nvim)


### PR DESCRIPTION
By default the error-leans.nvim plugin is not loaded, so I added a `event="LspAttach"` o make it work.  I also added a readme.

I added the presence.nvim plugin, using the default setup, and also added a readme.