### PR TITLE
Fix for lsp/lsplines by adding recommended setup: diagnose appear twice

### DIFF
--- a/lua/nvcommunity/lsp/lsplines/init.lua
+++ b/lua/nvcommunity/lsp/lsplines/init.lua
@@ -5,6 +5,7 @@ local spec = {
     event = "LspAttach",
     config = function()
       require("lsp_lines").setup()
+      vim.diagnostic.config({ virtual_text = false })
     end,
   },
 }


### PR DESCRIPTION
Add a recommended setup from [https://git.sr.ht/~whynothugo/lsp_lines.nvim#setup](https://git.sr.ht/~whynothugo/lsp_lines.nvim#setup). Otherwise, the diagnose will appear twice.