### PR TITLE
Fix: Added Dependencies for trouble.nvim

### DIFF
--- a/lua/nvcommunity/diagnostics/trouble/init.lua
+++ b/lua/nvcommunity/diagnostics/trouble/init.lua
@@ -2,6 +2,9 @@
 local spec = {
   "folke/trouble.nvim",
   cmd = { "Trouble", "TroubleToggle", "TodoTrouble" },
+  dependencies = {
+    "folke/todo-comments.nvim"
+  },
   opts = {},
   init = function()
     require("core.mappings").trouble = {


### PR DESCRIPTION
Added the missing plugin as an dependency for the TodoTrouble command to work.