### PR TITLE
Fix redundant ufo option

### DIFF
--- a/lua/nvcommunity/folds/ufo/init.lua
+++ b/lua/nvcommunity/folds/ufo/init.lua
@@ -104,7 +104,7 @@ local spec = {
       },
     },
     opts = {
-      close_fold_kinds = { "imports" },
+      close_fold_kinds_for_ft = { default = { "imports" } },
       provider_selector = function()
         return { "treesitter", "indent" }
       end,


### PR DESCRIPTION
`close_fold_kinds` has been deprecated in favour of
`close_fold_kinds_for_ft`. Here I update the format
keeping the same default value.